### PR TITLE
Create OH4 Bayesian Sensor system update

### DIFF
--- a/oh4/bayesian/bayesian_sensor_activation.yaml
+++ b/oh4/bayesian/bayesian_sensor_activation.yaml
@@ -1,0 +1,92 @@
+uid: jag_rules:bayesian_sensor_activation
+label: Bayesian Sensor Activation
+description: Calculate new probabilities for bayesian sensor groups
+configDescriptions: []
+triggers: []
+conditions: []
+actions:
+  - inputs: {}
+    id: "1"
+    configuration:
+      type: application/javascript
+      script: >
+        /****
+
+        / This Script calculates probabilities
+
+        / for the Bayesian sensor system.
+
+        ****/
+
+
+        //Logging
+
+        console.loggerName = 'org.openhab.automation.rule.bayesiansensor';
+
+        //osgi.getService('org.apache.karaf.log.core.LogService').setLevel(console.loggerName,
+        'INFO');
+
+        console.debug('Bayesian Sensor - Recalculating')
+
+
+        //Bayesian Probability Calculation
+
+        function updatePrior (updPrior, updPTrue, updPFalse, updItem) {
+          var numerator = updPTrue * updPrior;
+          var denominator = numerator + updPFalse * (1 - updPrior);
+          console.debug(`${updItem}: ${updPrior.toString()} -> ${(numerator / denominator).toString()}`);
+          return numerator / denominator;
+        }
+
+
+        //Find All Bayesian Sensor Groups for Event Item
+
+        var parentGroups = items.getItem(event.itemName).groupNames;
+
+        var sensorGroups = parentGroups.filter(x =>
+        items.getItem(x).tags.includes('Bayesian Sensor'));
+
+
+        //Define Test Object
+
+        var sensorTest = {
+          'gt': (sItem, test) => { return items[sItem].numericState > test[sItem].testState },
+          'lt': (sItem, test) => { return items[sItem].numericState < test[sItem].testState },
+          'bt': (sItem, test) => { return (test[sItem].testState[0] > items[sItem].numericState) && (items[sItem].numericState > test[sItem].testState[1]) },
+          'neq': (sItem, test) => { return items[it].state != sL[it].testState },
+          'list': (sItem, test) => { return test[sItem].testState.contains(items[sItem].state) },
+          'eq': (sItem, test) => { return items[sItem].state == test[sItem].testState }
+        }
+
+
+        //Read BayesianSensor MetaData and Iterate Through Sensors for Each
+        Impacted Sensor Group
+
+        for (var sensorGroup of sensorGroups) {
+          var metaList = items[sensorGroup].getMetadata('BayesianSensor');
+          if (!metaList || !metaList.configuration) {
+            console.error(`Bayesian metadata not configured for ${sensorGroup}`);
+          } else {
+            var sensorConfig = metaList.configuration;
+            var obsList = sensorConfig.obs;
+            var prior = sensorConfig.prior || 0.5;
+              for (var checkItem in obsList) {
+                if (sensorTest[obsList[checkItem].testType || 'eq'](checkItem, obsList)) {
+                  if (obsList[checkItem].decay) {
+                    var now = time.toZDT()
+                    var changedTime = time.toZDT(items.getItem(obsList[checkItem].decay.timestamp || checkItem + '_TS'));
+                    var decayTime = time.Duration.between(changedTime,now).toMinutes();
+                    var numSteps = Math.floor(decayTime / (obsList[checkItem].decay.timeStep || 5));
+                    var probTrue = Math.max((obsList[checkItem].decay.decayMin || .6),obsList[checkItem].pTrue - (numSteps * obsList[checkItem].decay.decayStep));
+                  } else {
+                    var probTrue = obsList[checkItem].pTrue;
+                  }
+                  prior = updatePrior(prior, probTrue,obsList[checkItem].pFalse,checkItem)
+                }
+              }
+            if (sensorConfig.posterior) items.getItem(sensorConfig.posterior).postUpdate(prior.toString());
+            items.getItem(sensorConfig.proxy).sendCommandIfDifferent((prior >= sensorConfig.threshold) ? (sensorConfig.trueState || 'ON') : (sensorConfig.falseState || 'OFF'));
+            console.debug(`${sensorGroup} new probability of ${prior} ${(prior >= sensorConfig.threshold) ? ' is over ' : 'is under '} ${sensorConfig.threshold}`);
+          }
+        }
+    type: script.ScriptAction

--- a/oh4/bayesian/bayesian_sensor_detail.yaml
+++ b/oh4/bayesian/bayesian_sensor_detail.yaml
@@ -1,0 +1,512 @@
+uid: bayesian_sensor_detail
+tags: []
+props:
+  parameters:
+    - context: item
+      description: Bayesian sensor item
+      name: sensor
+      required: true
+      type: TEXT
+      groupName: general
+    - context: rule
+      default: bayesian_widget_management
+      description: Linked rule for widget functions
+      label: Bayesian Management Rule
+      name: manageRule
+      required: false
+      type: TEXT
+      groupName: general
+    - default: "true"
+      description: Show labels for sensor items
+      label: Use Item Labels
+      name: useLabel
+      required: false
+      type: BOOLEAN
+  parameterGroups:
+    - name: general
+      label: General settings
+component: f7-block
+config:
+  stylesheet: |
+    .edit-grid {
+      grid-row-gap: 2px;
+      width: 100%;
+      display: grid;
+      grid-template-columns: 1fr 3fr 1fr 3fr 28px;
+      grid-template-rows: 1fr 1fr;
+      grid-template-areas:
+        "type-label type-input true-label true-input action-buttons" 
+        "state-label state-input false-label false-input action-buttons";
+      justify-items: center;
+    }
+    .edit-label {
+      font-weight: bold;
+    }
+    .edit-input {
+      padding-left: 3px;
+    }
+  class:
+    - block-narrow
+slots:
+  default:
+    - component: oh-repeater
+      config:
+        fetchMetadata: BayesianSensor
+        filter: loop.sensor.name == props.sensor
+        for: sensor
+        fragment: true
+        itemTags: Bayesian Sensor
+        key: =Math.random() + items.Widget_Settings_Bayesian_Sensor_Details.state
+        sourceType: itemsWithTags
+      slots:
+        default:
+          - component: f7-row
+            config:
+              style:
+                width: min(700px,100%)
+            slots:
+              default:
+                - component: f7-col
+                  slots:
+                    default:
+                      - component: oh-label-card
+                        config:
+                          label: =Number.parseFloat(items[loop.sensor.metadata.BayesianSensor.config.posterior].state).toFixed(3)
+                          style:
+                            width: 700px
+                          trendItem: =loop.sensor.metadata.BayesianSensor.config.posterior
+          - component: f7-row
+            config:
+              style:
+                width: min(720px,100%)
+            slots:
+              default:
+                - component: f7-col
+                  slots:
+                    default:
+                      - component: f7-block-title
+                        slots:
+                          default:
+                            - component: Label
+                              config:
+                                text: Sensor Details
+                      - component: f7-list
+                        slots:
+                          default:
+                            - component: oh-repeater
+                              config:
+                                for: detail
+                                fragment: true
+                                in:
+                                  - default: 0.5 (Default)
+                                    label: Prior
+                                    value: prior
+                                  - default: ERROR
+                                    label: Threshold
+                                    value: threshold
+                                  - default: ON (Default)
+                                    label: "True"
+                                    value: trueState
+                                  - default: OFF (Default)
+                                    label: "False"
+                                    value: falseState
+                                  - default: None
+                                    label: Prob Item
+                                    value: posterior
+                                  - default: ERROR
+                                    label: Proxy Item
+                                    value: proxy
+                                sourceType: array
+                              slots:
+                                default:
+                                  - component: oh-list-item
+                                    config:
+                                      after: =loop.sensor.metadata.BayesianSensor.config[loop.detail.value] ||
+                                        loop.detail.default
+                                      title: =loop.detail.label
+          - component: f7-row
+            config:
+              style:
+                width: min(720px,100%)
+            slots:
+              default:
+                - component: f7-col
+                  slots:
+                    default:
+                      - component: f7-block-title
+                        slots:
+                          default:
+                            - component: Label
+                              config:
+                                text: Sensor Observations
+                      - component: f7-list
+                        config:
+                          mediaList: true
+                          accordionList: true
+                          style:
+                            max-height: 200px
+                            overflow-y: scroll
+                        slots:
+                          default:
+                            - component: oh-repeater
+                              config:
+                                key: =Math.random + (vars.idxEdit || -1)
+                                for: observation
+                                fragment: true
+                                groupItem: =props.sensor
+                                sourceType: itemsInGroup
+                              slots:
+                                default:
+                                  - component: f7-list-item
+                                    config:
+                                      accordionItem: =loop.observation_idx + 1 == (vars.idxEdit || -1)
+                                      noChevron: true
+                                      accordionItemOpened: =loop.observation_idx + 1 == (vars.idxEdit || -1)
+                                      after: =`Current - ${items[loop.observation.name].state}`
+                                      subtitle: =((loop.sensor.metadata.BayesianSensor.config.obs[loop.observation.name].testType
+                                        !==
+                                        undefined)?(loop.sensor.metadata.BayesianSensor.config.obs[loop.observation.name].testType
+                                        + " - "):("eq - ")) +
+                                        ((JSON.stringify(loop.sensor.metadata.BayesianSensor.config.obs[loop.observation.name].testState).includes('['))?(loop.sensor.metadata.BayesianSensor.config.obs[loop.observation.name].testState.join(',
+                                        ')):(JSON.stringify(loop.sensor.metadata.BayesianSensor.config.obs[loop.observation.name].testState).replaceAll('"','')))
+                                      title: =((props.useLabel)?(loop.observation.label):(loop.observation.name))
+                                      swipeout: true
+                                      style:
+                                        pointer-events: =((vars.idxEdit || -1) > 0)?('none'):('auto')
+                                    slots:
+                                      default:
+                                        - component: f7-swipeout-actions
+                                          config:
+                                            left: true
+                                          slots:
+                                            default:
+                                              - component: oh-link
+                                                config:
+                                                  class:
+                                                    - swipeout-close
+                                                  action: rule
+                                                  actionRule: =props.manageRule
+                                                  actionRuleContext:
+                                                    modify: DELETE
+                                                    modifyItem: =props.sensor
+                                                    modifyValue: =loop.observation.name
+                                                  bgColor: red
+                                                  iconF7: trash_fill
+                                              - component: oh-link
+                                                config:
+                                                  class:
+                                                    - swipeout-close
+                                                  action: variable
+                                                  actionVariable: idxEdit
+                                                  actionVariableValue: =loop.observation_idx + 1
+                                                  bgColor: blue
+                                                  iconF7: pencil
+                                              - component: f7-link
+                                                config:
+                                                  class:
+                                                    - swipeout-close
+                                                  bgColor: green
+                                                  href: ='/settings/items/' + loop.observation.name
+                                                  iconF7: arrowshape_turn_up_right_fill
+                                        - component: f7-accordion-content
+                                          config:
+                                            style:
+                                              pointer-events: auto
+                                          slots:
+                                            default:
+                                              - component: div
+                                                config:
+                                                  class:
+                                                    - edit-grid
+                                                slots:
+                                                  default:
+                                                    - component: Label
+                                                      config:
+                                                        text: Test type
+                                                        class:
+                                                          - edit-label
+                                                        style:
+                                                          grid-area: type-label
+                                                    - component: oh-input
+                                                      config:
+                                                        defaultValue: =loop.sensor.metadata.BayesianSensor.config.obs[loop.observation.name].testType
+                                                          || 'eq'
+                                                        type: text
+                                                        variable: editTestType
+                                                        outline: true
+                                                        class:
+                                                          - edit-input
+                                                        style:
+                                                          grid-area: type-input
+                                                    - component: Label
+                                                      config:
+                                                        text: Test state
+                                                        class:
+                                                          - edit-label
+                                                        style:
+                                                          grid-area: state-label
+                                                    - component: oh-input
+                                                      config:
+                                                        defaultValue: =loop.sensor.metadata.BayesianSensor.config.obs[loop.observation.name].testState
+                                                        type: text
+                                                        variable: editTestState
+                                                        outline: true
+                                                        class:
+                                                          - edit-input
+                                                        style:
+                                                          grid-area: state-input
+                                                    - component: Label
+                                                      config:
+                                                        text: True prior
+                                                        class:
+                                                          - edit-label
+                                                        style:
+                                                          grid-area: true-label
+                                                    - component: oh-input
+                                                      config:
+                                                        defaultValue: =loop.sensor.metadata.BayesianSensor.config.obs[loop.observation.name].pTrue
+                                                        type: number
+                                                        step: 0.05
+                                                        max: 1
+                                                        min: 0
+                                                        variable: editPTrue
+                                                        outline: true
+                                                        class:
+                                                          - edit-input
+                                                        style:
+                                                          grid-area: true-input
+                                                    - component: Label
+                                                      config:
+                                                        text: False prior
+                                                        class:
+                                                          - edit-label
+                                                        style:
+                                                          grid-area: false-label
+                                                    - component: oh-input
+                                                      config:
+                                                        defaultValue: =loop.sensor.metadata.BayesianSensor.config.obs[loop.observation.name].pFalse
+                                                        type: number
+                                                        step: 0.05
+                                                        max: 1
+                                                        min: 0
+                                                        variable: editPFalse
+                                                        outline: true
+                                                        class:
+                                                          - edit-input
+                                                        style:
+                                                          grid-area: false-input
+                                                    - component: f7-col
+                                                      config:
+                                                        style:
+                                                          display: flex
+                                                          flex-direction: column
+                                                          grid-area: action-buttons
+                                                          justify-content: space-around
+                                                          align-items: center
+                                                          height: 100%
+                                                      slots:
+                                                        default:
+                                                          - component: oh-link
+                                                            config:
+                                                              iconF7: xmark_circle_fill
+                                                              iconColor: red
+                                                              clearVariable:
+                                                                - idxEdit
+                                                                - editTestType
+                                                                - editTestState
+                                                                - editPTrue
+                                                                - editPFalse
+                                                              iconSize: 24
+                                                          - component: oh-link
+                                                            config:
+                                                              iconF7: checkmark_circle_fill
+                                                              iconColor: green
+                                                              action: rule
+                                                              actionRule: =props.manageRule
+                                                              actionRuleContext:
+                                                                modify: UPDATEOBS
+                                                                modifyItem: =props.sensor
+                                                                modifyObs: =loop.observation.name
+                                                                modifyValue:
+                                                                  testType: =vars.editTestType ||
+                                                                    loop.sensor.metadata.BayesianSensor.config.obs[loop.observation.name].testType
+                                                                  testState: =vars.editTestState ||
+                                                                    loop.sensor.metadata.BayesianSensor.config.obs[loop.observation.name].testState
+                                                                  pTrue: =vars.editPTrue ||
+                                                                    loop.sensor.metadata.BayesianSensor.config.obs[loop.observation.name].pTrue
+                                                                  pFalse: =vars.editPFalse ||
+                                                                    loop.sensor.metadata.BayesianSensor.config.obs[loop.observation.name].pFalse
+                                                              iconSize: 24
+                                                              clearVariable:
+                                                                - idxEdit
+                                                                - editTestType
+                                                                - editTestState
+                                                                - editPTrue
+                                                                - editPFalse
+          - component: f7-row
+            config:
+              style:
+                width: min(720px,100%)
+            slots:
+              default:
+                - component: f7-col
+                  slots:
+                    default:
+                      - component: f7-block-title
+                        slots:
+                          default:
+                            - component: Label
+                              config:
+                                text: Sensor Audit
+                      - component: f7-list
+                        config:
+                          mediaList: true
+                        slots:
+                          default:
+                            - component: oh-list-item
+                              config:
+                                icon: f7:question_circle_fill
+                                iconColor: black
+                                title: No audit information
+                                visible: =!loop.sensor.metadata.BayesianSensor.config?.audit
+                            - component: oh-list-item
+                              config:
+                                icon: f7:checkmark_circle_fill
+                                iconColor: green
+                                title: Audit passed - no errors or warnings
+                                visible: =!!loop.sensor.metadata.BayesianSensor.config?.audit?.passed
+                            - component: oh-repeater
+                              config:
+                                for: auditError
+                                fragment: true
+                                rangeStart: 1
+                                rangeStop: =Number(loop.sensor.metadata.BayesianSensor.config.audit.errors.number)
+                                sourceType: range
+                                visible: =!!loop.sensor.metadata.BayesianSensor.config?.audit?.errors?.number
+                              slots:
+                                default:
+                                  - component: oh-list-item
+                                    config:
+                                      icon: f7:exclamationmark_circle_fill
+                                      iconColor: red
+                                      title: =loop.sensor.metadata.BayesianSensor.config.audit.errors.list[loop.auditError-1]
+                            - component: oh-repeater
+                              config:
+                                for: auditWarning
+                                fragment: true
+                                rangeStart: 1
+                                rangeStop: =Number(loop.sensor.metadata.BayesianSensor.config.audit.warnings.number)
+                                sourceType: range
+                                visible: =!!loop.sensor.metadata.BayesianSensor.config?.audit?.warnings?.number
+                              slots:
+                                default:
+                                  - component: oh-list-item
+                                    config:
+                                      icon: f7:flag_circle_fill
+                                      iconColor: yellow
+                                      title: =loop.sensor.metadata.BayesianSensor.config.audit.warnings.list[loop.auditWarning-1]
+          - component: f7-row
+            config:
+              style:
+                width: min(720px,100%)
+            slots:
+              default:
+                - component: f7-col
+                  slots:
+                    default:
+                      - component: f7-list
+                        config:
+                          style:
+                            width: 100%
+                        slots:
+                          default:
+                            - component: oh-list-item
+                              config:
+                                action: analyzer
+                                actionAnalyzerItems: =[loop.sensor.metadata.BayesianSensor.config.proxy,(loop.sensor.metadata.BayesianSensor.config.posterior)?(loop.sensor.metadata.BayesianSensor.config.posterior):('')]
+                                listButton: true
+                                title: Show Chart
+                            - component: oh-list-item
+                              config:
+                                action: rule
+                                actionRule: =props.manageRule
+                                actionRuleContext:
+                                  modify: AUDIT
+                                  modifyItem: =loop.sensor.name
+                                listButton: true
+                                title: Audit Configuration
+                            - component: oh-list-item
+                              config:
+                                action: variable
+                                actionVariable: showNewObs
+                                actionVariableValue: true
+                                listButton: true
+                                title: Add Observation Item
+                                visible: =!vars.showNewObs
+                            - component: f7-list-item-row
+                              config:
+                                style:
+                                  padding-top: 5px
+                                  margin-bottom: 2px
+                                visible: =!!vars.showNewObs
+                              slots:
+                                default:
+                                  - component: Label
+                                    config:
+                                      text: Observation Name
+                                      style:
+                                        flex-shrink: 0
+                                        padding-top: 1px
+                                        margin-right: 5px
+                                        margin-left: 10px
+                                  - component: oh-input
+                                    config:
+                                      type: text
+                                      outline: true
+                                      variable: addObsItem
+                                      placeholder: Name of Observation Item
+                                      style:
+                                        flex-grow: 1
+                                  - component: f7-row
+                                    config:
+                                      style:
+                                        flex-grow: 0
+                                        flex-wrap: nowrap
+                                        justify-content: flex-end
+                                        width: min-content
+                                    slots:
+                                      default:
+                                        - component: oh-link
+                                          config:
+                                            action: variable
+                                            actionVariable: showNewObs
+                                            actionVariableValue: false
+                                            clearVariable:
+                                              - addObsItem
+                                            iconF7: xmark_circle_fill
+                                            style:
+                                              padding: 3px 0 1px 15px
+                                        - component: oh-link
+                                          config:
+                                            action: rule
+                                            actionRule: =props.manageRule
+                                            actionRuleContext:
+                                              modify: ADD
+                                              modifyItem: =props.sensor
+                                              modifyValue: =vars.addObsItem
+                                            clearVariable:
+                                              - showNewObs
+                                              - addObsItem
+                                            iconF7: checkmark_circle_fill
+                                            style:
+                                              padding: 3px 10px 1px 15px
+                            - component: f7-list-button
+                              config:
+                                color: blue
+                                link: ='/settings/items/' + loop.sensor.name + '/metadata/BayesianSensor'
+                                title: Edit Metadata
+                            - component: f7-list-button
+                              config:
+                                color: blue
+                                link: ='/settings/items/' + loop.sensor.name
+                                title: Edit Group Item

--- a/oh4/bayesian/bayesian_sensor_list.yaml
+++ b/oh4/bayesian/bayesian_sensor_list.yaml
@@ -1,0 +1,388 @@
+uid: bayesian_sensor_list
+tags: []
+props:
+  parameters:
+    - context: rule
+      default: bayesian_widget_management
+      description: Linked rule for widget functions
+      label: Bayesian Management Rule
+      name: manageRule
+      required: false
+      type: TEXT
+      groupName: general
+    - context: page
+      default: page:settings_bayesian_details
+      description: Page to display for sensor details
+      label: Bayesian Sensor Details Page
+      name: detailPage
+      required: false
+      type: TEXT
+      groupName: general
+  parameterGroups:
+    - name: general
+      label: General settings
+component: f7-block
+config:
+  class:
+    - block-narrow
+    - after-big-title
+  style:
+    justify-content: flex-start
+    height: calc(100vh - var(--f7-navbar-height) - var(--f7-tabbar-labels-height) -
+      var(--f7-safe-area-top) - var(--f7-safe-area-bottom) - 80px)
+    margin: 0
+    padding: 0
+slots:
+  default:
+    - component: f7-row
+      config:
+        style:
+          flex-direction: column
+          width: min(720px,100%)
+          justify-content: flex-start
+      slots:
+        default:
+          - component: oh-repeater
+            config:
+              for: sensorCount
+              fragment: true
+              itemTags: Bayesian Sensor
+              sourceType: itemsWithTags
+            slots:
+              default:
+                - component: f7-block-title
+                  config:
+                    visible: =(loop.sensorCount_idx==0)
+                  slots:
+                    default:
+                      - component: Label
+                        config:
+                          text: =loop.sensorCount_source.length + " Bayesain Sensors"
+          - component: f7-list
+            config:
+              mediaList: true
+              style:
+                margin: 0
+                padding: 0
+                width: 100%
+            slots:
+              default:
+                - component: oh-repeater
+                  config:
+                    fetchMetadata: BayesianSensor
+                    for: sensorGroup
+                    fragment: true
+                    itemTags: Bayesian Sensor
+                    key: =Math.random() + items.Widget_Settings_Bayesian_Sensor_Details.state
+                    sourceType: itemsWithTags
+                  slots:
+                    default:
+                      - component: oh-list-item
+                        config:
+                          action: navigate
+                          actionPage: =props.detailPage
+                          actionPageDefineVars:
+                            bayesianItem: =loop.sensorGroup.name
+                          footer: =loop.sensorGroup.name
+                          name: sensorSelectRadio
+                          title: =loop.sensorGroup.label
+                        slots:
+                          after:
+                            - component: f7-chip
+                              config:
+                                iconF7: "=(!!loop.sensorGroup.metadata.BayesianSensor.config.audit) ?
+                                  ((loop.sensorGroup.metadata.BayesianSensor.co\
+                                  nfig.audit.errors) ? 'exclamationmark' :
+                                  ((loop.sensorGroup.metadata.BayesianSensor.co\
+                                  nfig.audit.warnings) ? 'flag_fill' :
+                                  'checkmark' )) : 'question'"
+                                mediaBgColor: "=(!!loop.sensorGroup.metadata.BayesianSensor.config.audit) ?
+                                  ((loop.sensorGroup.metadata.BayesianSensor.co\
+                                  nfig.audit.errors) ? 'red' :
+                                  ((loop.sensorGroup.metadata.BayesianSensor.co\
+                                  nfig.audit.warnings) ? 'yellow' : 'green' )) :
+                                  'black'"
+                                style:
+                                  margin-left: 10px
+                                text: =Number(items[loop.sensorGroup.metadata.BayesianSensor.config.posterior].state).toFixed(3)
+                                  + ' / ' +
+                                  loop.sensorGroup.metadata.BayesianSensor.config.threshold
+                                tooltip: "=(loop.sensorGroup.metadata.BayesianSensor.config.audit) ?
+                                  ((loop.sensorGroup.metadata.BayesianSensor.co\
+                                  nfig.audit.passed) ? 'All checks passed' :
+                                  ((loop.sensorGroup.metadata.BayesianSensor.co\
+                                  nfig.audit.warnings &&
+                                  loop.sensorGroup.metadata.BayesianSensor.conf\
+                                  ig.audit.warnings.number) || 0) + ' warnings
+                                  and ' +
+                                  ((loop.sensorGroup.metadata.BayesianSensor.co\
+                                  nfig.audit.errors &&
+                                  loop.sensorGroup.metadata.BayesianSensor.conf\
+                                  ig.audit.errors.number) || 0) + ' errors') :
+                                  'Metadata unaudited'"
+    - component: f7-block
+      config:
+        style:
+          height: calc(100vh - var(--f7-navbar-height) - var(--f7-tabbar-labels-height) -
+            var(--f7-safe-area-top) - var(--f7-safe-area-bottom) - 80px)
+          position: absolute
+          top: 0
+          width: 100%
+          z-index: 0
+          margin: 0
+          padding: 0
+      slots:
+        default:
+          - component: f7-fab
+            config:
+              color: blue
+              position: right-bottom
+            slots:
+              link:
+                - component: f7-icon
+                  config:
+                    f7: plus
+                - component: f7-icon
+                  config:
+                    f7: xmark
+              root:
+                - component: f7-fab-buttons
+                  config:
+                    position: top
+                  slots:
+                    default:
+                      - component: f7-fab-button
+                        config:
+                          fabClose: true
+                          label: Create New Group
+                        slots:
+                          default:
+                            - component: oh-link
+                              config:
+                                iconF7: rectangle_stack_badge_plus
+                                popupOpen: .popup.pop-create-group
+                      - component: f7-fab-button
+                        config:
+                          fabClose: true
+                          label: Create From Existing
+                        slots:
+                          default:
+                            - component: oh-link
+                              config:
+                                iconF7: list_bullet
+                                popupOpen: .popup.pop-new-bay-group
+    - component: f7-popup
+      config:
+        class:
+          - pop-new-bay-group
+      slots:
+        default:
+          - component: f7-page
+            config:
+              style:
+                overflow-y: hidden
+            slots:
+              default:
+                - component: f7-navbar
+                  config:
+                    style:
+                      position: sticky
+                    title: Make Group Bayesian Sensor
+                  slots:
+                    left:
+                      - component: oh-link
+                        config:
+                          clearVariable: selectedGroup
+                          iconF7: arrow_left
+                          popupClose: .popup.pop-new-bay-group
+                    right:
+                      - component: oh-link
+                        config:
+                          action: rule
+                          actionRule: =props.manageRule
+                          actionRuleContext:
+                            modify: SETUP
+                            modifyItem: =vars.selectedGroup
+                          clearVariable: selectedGroup
+                          text: Create
+                          visible: =!!vars.selectedGroup
+                - component: oh-list
+                  config:
+                    style:
+                      overflow-y: scroll
+                  slots:
+                    default:
+                      - component: oh-repeater
+                        config:
+                          filter: loop.ohItem.type=='Group' && !loop.ohItem.tags.includes('Bayesian
+                            Sensor')
+                          for: ohItem
+                          fragment: true
+                          itemTags: ","
+                          sourceType: itemsWithTags
+                        slots:
+                          default:
+                            - component: oh-list-item
+                              config:
+                                action: variable
+                                actionVariable: selectedGroup
+                                actionVariableValue: =loop.ohItem.name
+                                after: =loop.ohItem.name
+                                checked: =(vars.selectedGroup == loop.ohItem.name)
+                                name: groupSelectRadio
+                                radio: true
+                                title: =loop.ohItem.label
+    - component: f7-popup
+      config:
+        class:
+          - pop-create-group
+      slots:
+        default:
+          - component: f7-page
+            config:
+              style:
+                overflow-y: hidden
+              stylesheet: |
+                .item-title, .item-title-row {
+                  width: 100%;                  
+                }
+            slots:
+              default:
+                - component: f7-navbar
+                  config:
+                    title: Create New Sensor Group
+                  slots:
+                    left:
+                      - component: oh-link
+                        config:
+                          iconF7: chevron_left
+                          popupClose: .popup.pop-create-group
+                          text: Cancel
+                          clearVariable:
+                            - createGroupName
+                            - createGroupLabel
+                            - createGroupProxy
+                            - createGroupPosterior
+                - component: oh-list
+                  config:
+                    mediaList: true
+                    style:
+                      margin-left: 5px
+                      margin-right: 5px
+                  slots:
+                    default:
+                      - component: f7-list-item
+                        slots:
+                          title:
+                            - component: f7-row
+                              config:
+                                style:
+                                  width: 100%
+                              slots:
+                                default:
+                                  - component: Label
+                                    config:
+                                      style:
+                                        width: 25%
+                                      text: Name
+                                  - component: oh-input
+                                    config:
+                                      clearButton: true
+                                      defaultValue: NewGroup
+                                      errorMessage: Required. Alphanumeric & underscores only
+                                      pattern: "[A-Za-z0-9_]*"
+                                      placeholder: Name
+                                      style:
+                                        width: 75%
+                                      type: text
+                                      validate: true
+                                      variable: createGroupName
+                      - component: f7-list-item
+                        slots:
+                          title:
+                            - component: f7-row
+                              slots:
+                                default:
+                                  - component: Label
+                                    config:
+                                      style:
+                                        width: 25%
+                                      text: Label
+                                  - component: oh-input
+                                    config:
+                                      clearButton: true
+                                      defaultValue: New Group
+                                      placeholder: Label
+                                      style:
+                                        width: 75%
+                                      type: text
+                                      variable: createGroupLabel
+                      - component: f7-list-item
+                        slots:
+                          title:
+                            - component: f7-row
+                              config:
+                                style:
+                                  justify-content: space-between
+                              slots:
+                                default:
+                                  - component: Label
+                                    config:
+                                      style:
+                                        width: 25%
+                                      text: New Proxy Item
+                                  - component: oh-link
+                                    config:
+                                      action: variable
+                                      actionVariable: createGroupProxy
+                                      actionVariableValue: =!vars.createGroupProxy
+                                    slots:
+                                      default:
+                                        - component: f7-checkbox
+                                          config:
+                                            checked: =!vars.createGroupProxy
+                      - component: f7-list-item
+                        slots:
+                          title:
+                            - component: f7-row
+                              slots:
+                                default:
+                                  - component: Label
+                                    config:
+                                      style:
+                                        width: 25%
+                                      text: New Posterior Item
+                                  - component: oh-link
+                                    config:
+                                      action: variable
+                                      actionVariable: createGroupPosterior
+                                      actionVariableValue: =!vars.createGroupPosterior
+                                    slots:
+                                      default:
+                                        - component: f7-checkbox
+                                          config:
+                                            checked: =!!vars.createGroupPosterior
+                - component: oh-button
+                  config:
+                    action: rule
+                    actionRule: =props.manageRule
+                    actionRuleContext:
+                      modify: CREATE
+                      modifyItem: =vars.createGroupName
+                      modifyValue:
+                        label: =vars.createGroupLabel
+                        posterior: =!!vars.createGroupPosterior
+                        proxy: =!vars.createGroupProxy
+                    bgColor: blue
+                    fill: true
+                    large: true
+                    popupClose: .popup.pop-create-group
+                    style:
+                      margin-left: 37%
+                      width: 26%
+                    text: Create
+                    clearVariable:
+                      - createGroupName
+                      - createGroupLabel
+                      - createGroupProxy
+                      - createGroupPosterior

--- a/oh4/bayesian/bayesian_sensor_management.yaml
+++ b/oh4/bayesian/bayesian_sensor_management.yaml
@@ -1,0 +1,255 @@
+uid: jag_rules:bayesian_sensor_management
+label: Bayesian Sensor Management
+description: Respond to events from Bayesian Sensor widgets
+configDescriptions: []
+triggers: []
+conditions: []
+actions:
+  - inputs: {}
+    id: "2"
+    configuration:
+      type: application/javascript;version=ECMAScript-2021
+      script: >-
+        /****
+
+        / This Script provides administrative functions
+
+        / for the Bayesian sensor control system.
+
+        ****/
+
+
+        //Logging
+
+        console.loggerName = 'org.openhab.automation.rule.BayesianModify';
+
+        //osgi.getService('org.apache.karaf.log.core.LogService').setLevel(console.loggerName,
+        'DEBUG');
+
+        console.debug('Bayesian Management - Running')
+
+
+        //Check Widget Item
+
+        var widgetItem =
+        items.getItem('Widget_Settings_Bayesian_Sensor_Details',true)
+
+        if (!widgetItem) {
+          console.warn('No widget control item: creating...')
+          var newConfig = {
+            name: 'Widget_Settings_Bayesian_Sensor_Details',
+            type:'Number',
+            label: 'Bayesian Sensor Detail Widget Refresh',
+          }
+          items.addItem(newConfig)  
+        }
+
+
+        //Build Default BayesianSensor Metadata
+
+        var defaultConfig = {
+          proxy: 'Proxy_Item_Name',
+          trueState: 'ON',
+          falseState: 'OFF',
+          prior: 0.5,
+          threshold: 0.9,
+          obs: {}
+        }
+
+
+        //Audit Function
+
+        var runAudit = function (sensorItem) {
+          var sensorMetadata =  sensorItem.getMetadata('BayesianSensor')
+          if (!sensorMetadata) {
+            console.error(sensorItem.name + ' has no BayesianSensor metadata')
+          } else {
+            var errors = []
+            var warnings = []
+            var sensorConfig = sensorMetadata['configuration']
+            if (!sensorConfig) {
+              errors.push(sensorItem.name + ' BayesianSensor metadata has no configuration settings')
+              var sensorConfig = {}
+            } else {
+              if (!sensorConfig.proxy) errors.push('No proxy item set')
+              if (!sensorConfig.threshold) errors.push('threshold not set')
+              if (!sensorConfig.prior) warnings.push('prior not set - default 0.5 will be used')
+              if (!sensorConfig.trueState) warnings.push('trueState not set - default ON will be used')
+              if (!sensorConfig.falseState) warnings.push('falseState not set - default OFF will be used')
+              if (!sensorConfig.posterior) warnings.push('posterior not set - probability will not be recorded')
+              if (sensorConfig.sensors && !sensorConfig.obs) {
+                console.warn('OH3 configuration found. Updating...')
+                sensorConfig.obs = utils.javaMapToJsObj(sensorConfig.sensors)
+                delete sensorConfig.sensors
+              }
+              if (sensorConfig.sensors) warnings.push('old sensor config still present - will be ignored')
+              if (sensorConfig?.obs?.keySet) {
+                console.warn('OH3 configuration format found. Updating...')
+                sensorConfig.obs = utils.javaMapToJsObj(sensorConfig.obs)
+              }
+              if (!sensorConfig.obs) {
+                errors.push('observation array not set')
+              } else {
+                var obsList = Object.keys(sensorConfig.obs)
+                if (obsList.length == 0) {
+                  errors.push('no observations configured')
+                } else {
+                  var groupMembers = sensorItem.members
+                  var memberNames = groupMembers.map(function(memb) {return memb.name})
+                  var extraConfigs = obsList.filter(x => !memberNames.includes(x))
+                  if (extraConfigs.length > 0) warnings.push(extraConfigs.toString() + ((extraConfigs.length == 1) ? ' is not a group member item' : ' are not group member items') + ' - configurations will be ignored')
+                  for (var groupMember of groupMembers) {
+                    if (!sensorConfig.obs[groupMember.name]) {
+                      errors.push('No observation configuration for group member ' + groupMember.name)
+                    } else {
+                      if (sensorConfig.obs[groupMember.name].testState === undefined) errors.push(groupMember.name + ' has no testState')
+                      if (sensorConfig.obs[groupMember.name].pTrue === undefined) errors.push(groupMember.name + ' has no pTrue')
+                      if (sensorConfig.obs[groupMember.name].pFalse === undefined) errors.push(groupMember.name + ' has no pFalse')
+                      if (sensorConfig.obs[groupMember.name].testType !== undefined && !(['gt','lt','bt','neq','list','eq']).includes(sensorConfig.obs[groupMember.name].testType)) {
+                        warnings.push(groupMember.name + ' has invalid testType - default "equals" will be used')
+                      }
+                      var decaySettings = sensorConfig.obs[groupMember.name].decay
+                      if (decaySettings !== undefined) {
+                        if (decaySettings.decayStep === undefined) errors.push(groupMember.name + ' decay set with no decayStep')
+                        if (decaySettings.timestamp === undefined) warnings.push(groupMember.name + ' has no decay timestamp - default ' + groupMember.name + '_TS will be used')
+                        if (decaySettings.timeStep === undefined) warnings.push(groupMember.name + ' has no decay timeStep - default step of 5 minutes will be used')
+                        if (decaySettings.decayMin === undefined) warnings.push(groupMember.name + ' has no decayMin - default minimum probability of 0.6 will be used')
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            var newConfig = {}
+            for (var property in sensorConfig) {
+              if (property != 'aduit') newConfig[property] = sensorConfig[property]
+            }
+            newConfig.audit = {}
+            if (errors.length > 0) {
+              console.error(sensorItem.name + ' Configuration Errors:\n\t' + errors.join('\n\t'))
+              newConfig.audit.errors = {number: errors.length, list: Object.fromEntries(errors.entries())}
+            }
+            if (warnings.length > 0) {
+              console.warn(sensorItem.name + ' Configuration Warnings:\n\t' + warnings.join('\n\t'))
+              newConfig.audit.warnings = {number: warnings.length, list: Object.fromEntries(warnings.entries())}
+            }
+            if (warnings.length == 0 && errors.length == 0) {
+              console.info(sensorItem.name + ' Configuration Audit: Passed')
+              newConfig.audit.passed = true
+            }
+            sensorItem.replaceMetadata('BayesianSensor', sensorMetadata.value, newConfig)
+          }  
+        }
+
+
+        console.debug(`Modification: ${modify}`)
+
+        console.debug(`Item: ${modifyItem}`)
+
+
+        //Make Requested Modificaiton
+
+        switch (modify) {
+          case 'CREATE':
+            if (!items.getItem(modifyItem,true)) {
+              console.debug('Creating new bayesian group')
+              modifyValue = utils.javaMapToJsObj(modifyValue)
+              var groupConfig = {
+                name: modifyItem,
+                type: 'Group',
+                label: modifyValue.label || 'New Bayesian Group'
+              }
+              items.addItem(groupConfig)
+              if (modifyValue.proxy) {
+                console.debug(`Adding proxy item ${modifyItem + '_Proxy'}`)
+                var proxyConfig = {
+                  name: modifyItem + '_Proxy',
+                  type:'Switch',
+                  label: groupConfig.label + ' Proxy',
+                }
+                items.addItem(proxyConfig)
+                defaultConfig.proxy = proxyConfig.name
+              }
+              if (modifyValue.posterior) {
+                console.debug(`Adding Posterior item ${modifyItem + '_Posterior'}`)
+                var posteriorConfig = {
+                  name: modifyItem + '_Posterior',
+                  type:'Number',
+                  label: groupConfig.label + ' Posterior',
+                }
+                items.addItem(posteriorConfig)
+                defaultConfig.posterior = posteriorConfig.name
+              }
+            } else {
+              console.error('Item name already exists: Cannot create new item')
+              break
+            }
+          case 'SETUP':
+            console.debug('Initializing bayesian sensor settings')
+            items.getItem(modifyItem).addTags('Bayesian Sensor')
+            items.getItem(modifyItem).replaceMetadata('BayesianSensor',' ', defaultConfig)
+            break
+          case 'DELETE':
+            console.debug('Removing observation item')
+            items.getItem(modifyValue).removeGroups(modifyItem)
+            var sensorMetadata = items.getItem(modifyItem).getMetadata('BayesianSensor')
+            var sensorConfig = sensorMetadata.configuration
+            delete sensorConfig.obs[modifyValue]
+            items.getItem(modifyItem).replaceMetadata('BayesianSensor', sensorMetadata.value, sensorConfig)
+            break
+          case 'ADD':
+            console.debug('Adding observation item')
+            if (!items.getItem(modifyValue,true)) {
+              console.warn(`Item ${modifyValue} does not exist: cannot add to ${modifyItem}`)
+              break
+            }
+            items.getItem(modifyValue).addGroups(modifyItem)
+            var sensorMetadata = items.getItem(modifyItem).getMetadata('BayesianSensor')
+            var sensorConfig = sensorMetadata.configuration
+            sensorConfig.obs[modifyValue] = {testState: 'ON', pTrue: 0.75, pFalse: 0.5}
+            items.getItem(modifyItem).replaceMetadata('BayesianSensor', sensorMetadata.value, sensorConfig)
+            break
+          case 'UPDATEOBS':
+            console.debug('Updating observation item')
+            var sensorMetadata = items.getItem(modifyItem).getMetadata('BayesianSensor')
+            var sensorConfig = sensorMetadata.configuration
+            if (!modifyValue) {
+              console.warn('No new configuration provided: update cancelled')
+              break
+            } else if (!modifyObs) {
+              console.warn('No observation selected: update cancelled')
+              break
+            }
+            modifyValue = utils.javaMapToJsObj(modifyValue)
+            if (modifyValue.testType && !(['gt','lt','bt','neq','list','eq']).includes(modifyValue.testType)) {
+              console.warn(`Invalid test type ${modifyValue.testType}: ignoring`)
+              if (sensorConfig.obs[modifyObs].testType) {
+                modifyValue.testType = sensorConfig.obs[modifyObs].testType
+              } else {
+                delete modifyValue.testType
+              }
+            }
+            if (modifyValue.testState && Number(modifyValue.testState)) modifyValue.testState = Number(modifyValue.testState)
+            if (modifyValue.pTrue) modifyValue.pTrue = Number(modifyValue.pTrue)
+            if (modifyValue.pFalse) modifyValue.pFalse = Number(modifyValue.pFalse)
+            sensorConfig.obs[modifyObs] = modifyValue
+            items.getItem(modifyItem).replaceMetadata('BayesianSensor', sensorMetadata.value, sensorConfig)
+            break
+          case 'AUDIT':
+            console.debug('Bayesian Sensor Configuration Check')
+            runAudit(items.getItem(modifyItem))
+            break
+          case 'FULLAUDIT':
+            console.debug('Bayesian Sensor Full System Configuration Check')
+            var sensorList = items.getItemsByTag('Bayesian Sensor')
+            if (!sensorList) console.warn('No Bayesian Sensors Configured')
+            for (var sensor of sensorList) {
+              runAudit(sensor)
+            }
+            break
+        }
+          
+        //Cleanup
+
+        items['Widget_Settings_Bayesian_Sensor_Details'].postUpdate(Math.random())
+    type: script.ScriptAction


### PR DESCRIPTION
This adds rules for using bayesian sensors updated for OH4. The previous single widget is now split into two widgets styled to match OH settings and details pages.